### PR TITLE
Added MacOS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Balatro Music Patcher
 A simple program for patching custom music into Balatro. (Specifically Dom Palombi's covers.)
 
-This program uses 7zip to replace in-game files with the custom music. If 7zip is not installed, the program will download it for you, but it is
+On Windows this program uses 7zip to replace in-game files with the custom music. If 7zip is not installed, the program will download it for you, but it is
 recommended to install it yourself. [here](https://www.7-zip.org/)
 
 [Latest Windows Release](https://github.com/Nat3z/balatro-music-patch/releases/tag/1.0)
+
+# Windows
 
 ## Usage
 1. Download the latest release from the link above.
@@ -27,6 +29,39 @@ recommended to install it yourself. [here](https://www.7-zip.org/)
 2. Install pyinstaller with `pip install pyinstaller`.
 3. Run `pyinstaller --onefile main.py`.
 4. The executable will be in the `dist/` folder.
+
+# MacOS
+
+## Usage
+1. Download the latest release from the link above.
+2. Extract the zip file.
+3. Open terminal
+4. Navigate to the release directory
+5. Run `./main`
+6. Follow the instructions in the program.
+
+## Manually Patching Music
+2. Open the repository and navigate to the `resources/sounds/` folder.
+3. Download the music from this folder.
+4. Navigate to '~/Library/Application Support/Steam/steamapps/common/Balatro' (It's easiest to use 'Go To Folder' in the menu bar or Cmd-Shift-G)
+5. Right click on Balatro.app and click 'Show Package Contents'.
+6. Navigate to 'Contents/Resources/'
+7. Rename 'Balatro.love' to 'Balatro.zip'
+8. Double click 'Balatro.zip' to extract and navigate into the Balatro folder
+10. Navigate to the `resources/sounds/` folder.
+11. Drag and drop the music files into the folder.
+12. Return to the Balatro folder from step 7
+13. Press shift-A to select all, right click, and press 'Compress'
+14. Rename 'Archive.zip' to 'Balatro.love' and copy it to the 'Contents/Resources/' folder from step 5
+15. Delete the Balatro folder and 'Balatro.zip' from 'Contents/Resources/'
+16. Run Balatro.
+
+## Building from Source
+1. Clone the repository.
+2. Install pyinstaller with `pip install pyinstaller`.
+3. Run `pyinstaller --onefile main.py`.
+4. The executable will be in the `dist/` folder.
+5. Run the executable in a directory with the resources folder
 
 ## Credit
 - Dom Palombi for the music covers.

--- a/main.py
+++ b/main.py
@@ -1,78 +1,81 @@
-def main():
-    import subprocess
-    import os
-    import urllib.request
-    import shutil
-    import platform
+import subprocess
+import os
+import urllib.request
+import shutil
+import platform
 
-    os_platform = platform.system()
+def look_for_balatro_windows() -> str:
+    path = "C:/Program Files (x86)/Steam/steamapps/common/Balatro/Balatro.exe"
+    does_balatro_exist = os.path.isfile(path)
+    if does_balatro_exist:
+        print("Balatro found! " + path)
+    else:
+        print("Balatro not found in default path!")
+    
+    while not does_balatro_exist:
+        path = input("Enter the file path of Balatro (including /Balatro.exe at the end): ")
+        path = path.removeprefix("\"").removesuffix("\"")
 
-    sevenzip_download = "https://www.7-zip.org/a/7z1900-x64.exe"
-    def look_for_balatro_windows():
-        path = "C:/Program Files (x86)/Steam/steamapps/common/Balatro/Balatro.exe"
         does_balatro_exist = os.path.isfile(path)
         if does_balatro_exist:
             print("Balatro found! " + path)
         else:
-            print("Balatro not found in default path!")
-        
-        while not does_balatro_exist:
-            path = input("Enter the file path of Balatro (including /Balatro.exe at the end): ")
-            path = path.removeprefix("\"").removesuffix("\"")
+            print("Balatro not found in the path you entered!")
 
-            does_balatro_exist = os.path.isfile(path)
-            if does_balatro_exist:
-                print("Balatro found! " + path)
-            else:
-                print("Balatro not found in the path you entered!")
+    return os.path.realpath(path)
 
-        return os.path.realpath(path)
+def look_for_balatro_macos() -> str:
+    home_dir = os.path.expanduser("~")
+    relative_path = "Library/Application Support/Steam/steamapps/common/Balatro/Balatro.app"
+    path = os.path.join(home_dir, relative_path)
+    does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
+    if does_balatro_exist:
+        print("Balatro found! " + path)
+    else:
+        print("Balatro not found in default path!")
+    
+    while not does_balatro_exist:
+        path = input("Enter the file path of Balatro (including /Balatro.app at the end): ")
+        path = path.removeprefix("\"").removesuffix("\"")
 
-    def look_for_balatro_macos():
-        home_dir = os.path.expanduser("~")
-        relative_path = "Library/Application Support/Steam/steamapps/common/Balatro/Balatro.app"
-        path = os.path.join(home_dir, relative_path)
         does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
         if does_balatro_exist:
             print("Balatro found! " + path)
         else:
-            print("Balatro not found in default path!")
-        
-        while not does_balatro_exist:
-            path = input("Enter the file path of Balatro (including /Balatro.app at the end): ")
-            path = path.removeprefix("\"").removesuffix("\"")
+            print("Balatro not found in the path you entered!")
 
-            does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
-            if does_balatro_exist:
-                print("Balatro found! " + path)
-            else:
-                print("Balatro not found in the path you entered!")
+    path = os.path.join(path, "Contents/Resources/Balatro.love")
+    if not os.path.isfile(path):
+        print("Balatro directory corrupted")
+        return ""
+    return os.path.realpath(path)
 
-        path = os.path.join(path, "Contents/Resources/Balatro.love")
-        if not os.path.isfile(path):
-            print("Balatro directory corrupted, exiting...")
-            return
-        return os.path.realpath(path)
+def check_7zip():
+    sevenzip_download = "https://www.7-zip.org/a/7z1900-x64.exe"
+    try:
+        os.system("\"C:/Program Files/7-Zip/7z.exe\"")
+        print("7zip found!")
+    except FileNotFoundError:
+        print("7zip not found! Installing 7zip...")
+        # download 7zip
+        urllib.request.urlretrieve(sevenzip_download, "7zip.exe")
+        print("We will now open the 7zip installer. You will be asked for admin permissions.")
+        input("Press Enter to continue...")
+        print("Installing 7zip...")
+        subprocess.call("7zip.exe /S /D=C:/Program Files/7-Zip/")
+        print("7zip installed!")
 
-    def check_7zip():
-        try:
-            os.system("\"C:/Program Files/7-Zip/7z.exe\"")
-            print("7zip found!")
-        except FileNotFoundError:
-            print("7zip not found! Installing 7zip...")
-            # download 7zip
-            urllib.request.urlretrieve(sevenzip_download, "7zip.exe")
-            print("We will now open the 7zip installer. You will be asked for admin permissions.")
-            input("Press Enter to continue...")
-            print("Installing 7zip...")
-            subprocess.call("7zip.exe /S /D=C:/Program Files/7-Zip/")
-            print("7zip installed!")
+def main():
+    os_platform = platform.system()
 
     if os_platform == "Windows":    
         path = look_for_balatro_windows()
         check_7zip()
     elif os_platform == "Darwin":
         path = look_for_balatro_macos()
+        if (path == ""):
+            print("exiting...")
+            return
     # check if 7zip is installed
 
 

--- a/main.py
+++ b/main.py
@@ -1,90 +1,121 @@
-import subprocess
-import os
-import urllib.request
-import shutil
-import platform
+def main():
+    import subprocess
+    import os
+    import urllib.request
+    import shutil
+    import platform
 
-os_platform = platform.system()
+    os_platform = platform.system()
 
-sevenzip_download = "https://www.7-zip.org/a/7z1900-x64.exe"
-def look_for_balatro_windows():
-    path = "C:/Program Files (x86)/Steam/steamapps/common/Balatro/Balatro.exe"
-    does_balatro_exist = os.path.isfile(path)
-    if does_balatro_exist:
-        print("Balatro found! " + path)
-    else:
-        print("Balatro not found in default path!")
-    
-    while not does_balatro_exist:
-        path = input("Enter the file path of Balatro (including /Balatro.exe at the end): ")
-        path = path.removeprefix("\"").removesuffix("\"")
-
+    sevenzip_download = "https://www.7-zip.org/a/7z1900-x64.exe"
+    def look_for_balatro_windows():
+        path = "C:/Program Files (x86)/Steam/steamapps/common/Balatro/Balatro.exe"
         does_balatro_exist = os.path.isfile(path)
         if does_balatro_exist:
             print("Balatro found! " + path)
         else:
-            print("Balatro not found in the path you entered!")
+            print("Balatro not found in default path!")
+        
+        while not does_balatro_exist:
+            path = input("Enter the file path of Balatro (including /Balatro.exe at the end): ")
+            path = path.removeprefix("\"").removesuffix("\"")
 
-    return os.path.realpath(path)
+            does_balatro_exist = os.path.isfile(path)
+            if does_balatro_exist:
+                print("Balatro found! " + path)
+            else:
+                print("Balatro not found in the path you entered!")
 
-def look_for_balatro_macos():
-    home_dir = os.path.expanduser("~")
-    relative_path = "Library/Application Support/Steam/steamapps/common/Balatro/Balatro.app"
-    path = os.path.join(home_dir, relative_path)
-    does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
-    if does_balatro_exist:
-        print("Balatro found! " + path)
-    else:
-        print("Balatro not found in default path!")
-    
-    while not does_balatro_exist:
-        path = input("Enter the file path of Balatro (including /Balatro.app at the end): ")
-        path = path.removeprefix("\"").removesuffix("\"")
+        return os.path.realpath(path)
 
+    def look_for_balatro_macos():
+        home_dir = os.path.expanduser("~")
+        relative_path = "Library/Application Support/Steam/steamapps/common/Balatro/Balatro.app"
+        path = os.path.join(home_dir, relative_path)
         does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
         if does_balatro_exist:
             print("Balatro found! " + path)
         else:
-            print("Balatro not found in the path you entered!")
+            print("Balatro not found in default path!")
+        
+        while not does_balatro_exist:
+            path = input("Enter the file path of Balatro (including /Balatro.app at the end): ")
+            path = path.removeprefix("\"").removesuffix("\"")
 
-    path = os.path.join(path, "Contents/Resources/Balatro.love")
-    if not os.path.isfile(path):
-        print("Balatro directory corrupted, exiting...")
+            does_balatro_exist = os.path.exists(path) and os.path.isdir(path)
+            if does_balatro_exist:
+                print("Balatro found! " + path)
+            else:
+                print("Balatro not found in the path you entered!")
+
+        path = os.path.join(path, "Contents/Resources/Balatro.love")
+        if not os.path.isfile(path):
+            print("Balatro directory corrupted, exiting...")
+            return
+        return os.path.realpath(path)
+
+    def check_7zip():
+        try:
+            os.system("\"C:/Program Files/7-Zip/7z.exe\"")
+            print("7zip found!")
+        except FileNotFoundError:
+            print("7zip not found! Installing 7zip...")
+            # download 7zip
+            urllib.request.urlretrieve(sevenzip_download, "7zip.exe")
+            print("We will now open the 7zip installer. You will be asked for admin permissions.")
+            input("Press Enter to continue...")
+            print("Installing 7zip...")
+            subprocess.call("7zip.exe /S /D=C:/Program Files/7-Zip/")
+            print("7zip installed!")
+
+    if os_platform == "Windows":    
+        path = look_for_balatro_windows()
+        check_7zip()
+    elif os_platform == "Darwin":
+        path = look_for_balatro_macos()
+    # check if 7zip is installed
+
+
+    # open music folder read files
+    music_folder = os.path.join(os.getcwd(), "resources", "sounds")
+    music_files = os.listdir(music_folder)
+    sevenzip_path = "C:/Program Files/7-Zip/7z.exe"
+
+    if os.path.exists("./original/"):
+        print("Original music already extracted! Reversing patch...")
+        # change working directory to original
+        os.chdir("original")
+        # add files to balatro.exe
+        for file in music_files:
+            print("Replacing " + file + "...")
+            if os_platform == "Windows":
+                process = subprocess.Popen([sevenzip_path, "a", path, f"resources/sounds/{file}"])
+            elif os_platform == "Darwin":
+                process = subprocess.Popen(["zip", path, f"resources/sounds/{file}"])
+            process.wait()
+
+        # delete original folder
+        os.chdir("..")
+        shutil.rmtree("original")
+
+        print(chr(27) + "[2J")
+        print("Patch reversed! Enjoy the original music!")
         return
-    return os.path.realpath(path)
-
-def check_7zip():
-    try:
-        os.system("\"C:/Program Files/7-Zip/7z.exe\"")
-        print("7zip found!")
-    except FileNotFoundError:
-        print("7zip not found! Installing 7zip...")
-        # download 7zip
-        urllib.request.urlretrieve(sevenzip_download, "7zip.exe")
-        print("We will now open the 7zip installer. You will be asked for admin permissions.")
-        input("Press Enter to continue...")
-        print("Installing 7zip...")
-        subprocess.call("7zip.exe /S /D=C:/Program Files/7-Zip/")
-        print("7zip installed!")
-
-if os_platform == "Windows":    
-    path = look_for_balatro_windows()
-    check_7zip()
-elif os_platform == "Darwin":
-    path = look_for_balatro_macos()
-# check if 7zip is installed
 
 
-# open music folder read files
-music_folder = os.path.join(os.getcwd(), "resources", "sounds")
-music_files = os.listdir(music_folder)
-sevenzip_path = "C:/Program Files/7-Zip/7z.exe"
+    # extract balatro in specific path
+    print("Extracting Balatro.exe's original music...")
 
-if os.path.exists("./original/"):
-    print("Original music already extracted! Reversing patch...")
-    # change working directory to original
-    os.chdir("original")
-    # add files to balatro.exe
+    # create folder for original music
+    os.makedirs("original/resources/sounds", exist_ok=True)
+    for file in music_files:
+        print("Extracting " + file + "...")
+        if os_platform == "Windows":
+            process = subprocess.Popen([sevenzip_path, "e", path, f"resources/sounds/{file}", "-o" + "original/resources/sounds/"])
+        elif os_platform == "Darwin":
+            process = subprocess.Popen(["unzip", path, f"resources/sounds/{file}", "-d" + "original/"])
+        process.wait()
+    # replace files in balatro.exe's resources/sounds/ with 7zip
     for file in music_files:
         print("Replacing " + file + "...")
         if os_platform == "Windows":
@@ -93,35 +124,8 @@ if os.path.exists("./original/"):
             process = subprocess.Popen(["zip", path, f"resources/sounds/{file}"])
         process.wait()
 
-    # delete original folder
-    os.chdir("..")
-    shutil.rmtree("original")
-
     print(chr(27) + "[2J")
-    print("Patch reversed! Enjoy the original music!")
-    exit()
+    print("Patch applied! Enjoy your new music!")
 
-
-# extract balatro in specific path
-print("Extracting Balatro.exe's original music...")
-
-# create folder for original music
-os.makedirs("original/resources/sounds", exist_ok=True)
-for file in music_files:
-    print("Extracting " + file + "...")
-    if os_platform == "Windows":
-        process = subprocess.Popen([sevenzip_path, "e", path, f"resources/sounds/{file}", "-o" + "original/resources/sounds/"])
-    elif os_platform == "Darwin":
-        process = subprocess.Popen(["unzip", path, f"resources/sounds/{file}", "-d" + "original/"])
-    process.wait()
-# replace files in balatro.exe's resources/sounds/ with 7zip
-for file in music_files:
-    print("Replacing " + file + "...")
-    if os_platform == "Windows":
-        process = subprocess.Popen([sevenzip_path, "a", path, f"resources/sounds/{file}"])
-    elif os_platform == "Darwin":
-        process = subprocess.Popen(["zip", path, f"resources/sounds/{file}"])
-    process.wait()
-
-print(chr(27) + "[2J")
-print("Patch applied! Enjoy your new music!")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added support for MacOS installs of Balatro.

- Uses the built in 'zip' and 'unzip' commands rather than 7zip.
- Supports the different directory structure of the MacOS build
- Does not alter the original Windows code in any way apart from adding conditionals to check OS for platform specific code
- An executable can be compiled in the same way using pyinstaller, but you have to do it from a MacOS environment